### PR TITLE
issue/306 - reduce compile time by intruducing custom packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ python scripts/install.py [XMAKE_CONFIG_FLAGS]
 | `--sugon-dcu=[y\|n]`     | 是否编译曙光 DCU 接口实现         | n
 | `--kunlun-xpu=[y\|n]`    | 是否编译昆仑 XPU 接口实现         | n
 | `--ccl=[y\|n]`           | 是否编译 InfiniCCL 通信库接口实现 | n
-
+| `--prebuild=[y\|n]`      | 是否提前编译cub包，以减少编译耗时 | n
 ### 手动安装
 
 1. 项目配置
@@ -73,8 +73,9 @@ python scripts/install.py [XMAKE_CONFIG_FLAGS]
      ```shell
      # 英伟达
      # 可以指定 CUDA 路径， 一般环境变量为 `CUDA_HOME` 或者 `CUDA_ROOT`
-     xmake f --nv-gpu=true --cuda=$CUDA_HOME -cv
-
+     # 如果提前编译cub包，要将 prebuild 设置为 true
+     xmake f --nv-gpu=true --cuda=$CUDA_HOME --prebuild=false -cv
+     
      # 寒武纪
      xmake f --cambricon-mlu=true -cv
 

--- a/src/infinicub/include/cub_algorithms.cuh
+++ b/src/infinicub/include/cub_algorithms.cuh
@@ -1,0 +1,413 @@
+#ifndef __CUB_ALGORITHMS_CUH__
+#define __CUB_ALGORITHMS_CUH__
+
+#include <cstdint>
+#include <cub/cub.cuh>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+namespace infini_cub {
+
+cudaError cub_DeviceReduce_ArgMax(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *logits,
+    cub::KeyValuePair<int, __nv_bfloat16> *kv_pair,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceReduce_ArgMax(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *logits,
+    cub::KeyValuePair<int, half> *kv_pair,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceReduce_ArgMax(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *logits,
+    cub::KeyValuePair<int, float> *kv_pair,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceReduce_ArgMax(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *logits,
+    cub::KeyValuePair<int, double> *kv_pair,
+    int n,
+    cudaStream_t stream);
+
+} // namespace infini_cub
+
+namespace infini_cub {
+
+cudaError cub_DeviceScan_InclusiveSum(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    __nv_bfloat16 *data,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceScan_InclusiveSum(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    half *data,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceScan_InclusiveSum(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    float *data,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceScan_InclusiveSum(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    double *data,
+    int n,
+    cudaStream_t stream);
+} // namespace infini_cub
+
+namespace infini_cub {
+using uchar = uint8_t;
+using ushort = uint16_t;
+using uint = uint32_t;
+using ulong = uint64_t;
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const uchar *val_in,
+    uchar *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const int8_t *val_in,
+    int8_t *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const ushort *val_in,
+    ushort *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const short *val_in,
+    short *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const uint *val_in,
+    uint *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const int *val_in,
+    int *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const ulong *val_in,
+    ulong *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const long *val_in,
+    long *val_out,
+    int n,
+    cudaStream_t stream);
+
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const uchar *val_in,
+    uchar *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const int8_t *val_in,
+    int8_t *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const ushort *val_in,
+    ushort *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const short *val_in,
+    short *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const uint *val_in,
+    uint *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const int *val_in,
+    int *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const ulong *val_in,
+    ulong *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const long *val_in,
+    long *val_out,
+    int n,
+    cudaStream_t stream);
+
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const uchar *val_in,
+    uchar *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const int8_t *val_in,
+    int8_t *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const ushort *val_in,
+    ushort *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const short *val_in,
+    short *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const uint *val_in,
+    uint *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const int *val_in,
+    int *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const ulong *val_in,
+    ulong *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const long *val_in,
+    long *val_out,
+    int n,
+    cudaStream_t stream);
+
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const uchar *val_in,
+    uchar *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const int8_t *val_in,
+    int8_t *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const ushort *val_in,
+    ushort *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const short *val_in,
+    short *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const uint *val_in,
+    uint *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const int *val_in,
+    int *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const ulong *val_in,
+    ulong *val_out,
+    int n,
+    cudaStream_t stream);
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const long *val_in,
+    long *val_out,
+    int n,
+    cudaStream_t stream);
+
+} // namespace infini_cub
+
+#endif // __CUB_ALGORITHMS_CUH__

--- a/src/infinicub/src/cub_algorithms.cu
+++ b/src/infinicub/src/cub_algorithms.cu
@@ -1,0 +1,674 @@
+#include "cub_algorithms.cuh"
+#include <cub/cub.cuh>
+#include <cub/device/device_radix_sort.cuh>
+#include <cub/device/device_reduce.cuh>
+#include <cub/device/device_scan.cuh>
+
+namespace infini_cub {
+
+cudaError cub_DeviceReduce_ArgMax(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *logits,
+    cub::KeyValuePair<int, __nv_bfloat16> *kv_pair,
+    int n,
+    cudaStream_t stream) {
+
+    return cub::DeviceReduce::ArgMax(workspace_ptr, workspace_len, logits, kv_pair, n, stream);
+}
+
+cudaError cub_DeviceReduce_ArgMax(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *logits,
+    cub::KeyValuePair<int, half> *kv_pair,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceReduce::ArgMax(workspace_ptr, workspace_len, logits, kv_pair, n, stream);
+}
+
+cudaError cub_DeviceReduce_ArgMax(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *logits,
+    cub::KeyValuePair<int, float> *kv_pair,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceReduce::ArgMax(workspace_ptr, workspace_len, logits, kv_pair, n, stream);
+}
+
+cudaError cub_DeviceReduce_ArgMax(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *logits,
+    cub::KeyValuePair<int, double> *kv_pair,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceReduce::ArgMax(workspace_ptr, workspace_len, logits, kv_pair, n, stream);
+}
+} // namespace infini_cub
+
+namespace infini_cub {
+
+cudaError cub_DeviceScan_InclusiveSum(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    __nv_bfloat16 *data,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceScan::InclusiveSum(workspace_ptr, workspace_len, data, data, n, stream);
+}
+
+cudaError cub_DeviceScan_InclusiveSum(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    half *data,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceScan::InclusiveSum(workspace_ptr, workspace_len, data, data, n, stream);
+}
+
+cudaError cub_DeviceScan_InclusiveSum(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    float *data,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceScan::InclusiveSum(workspace_ptr, workspace_len, data, data, n, stream);
+}
+
+cudaError cub_DeviceScan_InclusiveSum(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    double *data,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceScan::InclusiveSum(workspace_ptr, workspace_len, data, data, n, stream);
+}
+} // namespace infini_cub
+
+namespace infini_cub {
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const uchar *val_in,
+    uchar *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const int8_t *val_in,
+    int8_t *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const ushort *val_in,
+    ushort *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const short *val_in,
+    short *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const uint *val_in,
+    uint *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const int *val_in,
+    int *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const ulong *val_in,
+    ulong *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const __nv_bfloat16 *key_in,
+    __nv_bfloat16 *key_out,
+    const long *val_in,
+    long *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const uchar *val_in,
+    uchar *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const int8_t *val_in,
+    int8_t *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const ushort *val_in,
+    ushort *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const short *val_in,
+    short *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const uint *val_in,
+    uint *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const int *val_in,
+    int *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const ulong *val_in,
+    ulong *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const half *key_in,
+    half *key_out,
+    const long *val_in,
+    long *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(half) * 8,
+        stream);
+}
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const uchar *val_in,
+    uchar *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(float) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const int8_t *val_in,
+    int8_t *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(float) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const ushort *val_in,
+    ushort *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(float) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const short *val_in,
+    short *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(float) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const uint *val_in,
+    uint *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(float) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const int *val_in,
+    int *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(float) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const ulong *val_in,
+    ulong *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(float) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const float *key_in,
+    float *key_out,
+    const long *val_in,
+    long *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(float) * 8,
+        stream);
+}
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+// --------------------------------------------------------------
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const uchar *val_in,
+    uchar *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(double) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const int8_t *val_in,
+    int8_t *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(double) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const ushort *val_in,
+    ushort *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(double) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const short *val_in,
+    short *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(double) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const uint *val_in,
+    uint *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(double) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const int *val_in,
+    int *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(double) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const ulong *val_in,
+    ulong *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        0, sizeof(double) * 8,
+        stream);
+}
+
+cudaError cub_DeviceRadixSort_SortPairsDescending(
+    void *workspace_ptr,
+    size_t &workspace_len,
+    const double *key_in,
+    double *key_out,
+    const long *val_in,
+    long *val_out,
+    int n,
+    cudaStream_t stream) {
+    return cub::DeviceRadixSort::SortPairsDescending(workspace_ptr, workspace_len,
+                                                     key_in, key_out,
+                                                     val_in, val_out,
+                                                     n,
+                                                     0, sizeof(double) * 8,
+                                                     stream);
+}
+} // namespace infini_cub

--- a/src/infinicub/xmake.lua
+++ b/src/infinicub/xmake.lua
@@ -1,0 +1,37 @@
+local CUDA_ROOT = os.getenv("CUDA_ROOT") or os.getenv("CUDA_HOME") or os.getenv("CUDA_PATH")
+local CUDNN_ROOT = os.getenv("CUDNN_ROOT") or os.getenv("CUDNN_HOME") or os.getenv("CUDNN_PATH")
+if CUDA_ROOT ~= nil then
+    add_includedirs(CUDA_ROOT .. "/include")
+end
+if CUDNN_ROOT ~= nil then
+    add_includedirs(CUDNN_ROOT .. "/include")
+end
+
+-- 静态库目标
+target("infinicub")
+    set_kind("static")
+    set_policy("build.cuda.devlink", true)
+    set_toolchains("cuda")
+    add_links("cublas", "cudnn")
+    add_cugencodes("native")
+
+    if is_plat("windows") then
+        add_cuflags("-Xcompiler=/utf-8", "--expt-relaxed-constexpr", "--allow-unsupported-compiler")
+        add_cuflags("-Xcompiler=/W3", "-Xcompiler=/WX")
+        add_cxxflags("/FS")
+        if CUDNN_ROOT ~= nil then
+            add_linkdirs(CUDNN_ROOT .. "\\lib\\x64")
+        end
+    else
+        add_cuflags("-Xcompiler=-Wall", "-Xcompiler=-Werror")
+        add_cuflags("-Xcompiler=-fPIC")
+        add_cuflags("--extended-lambda")
+        add_culdflags("-Xcompiler=-fPIC")
+        add_cxxflags("-fPIC")
+    end
+
+    set_languages("cxx17")
+    add_includedirs("include")
+
+    add_files("src/cub_algorithms.cu") 
+target_end()

--- a/src/infiniop/ops/random_sample/cuda/random_sample_kernel.cuh
+++ b/src/infiniop/ops/random_sample/cuda/random_sample_kernel.cuh
@@ -1,8 +1,13 @@
 ﻿#include "../../../devices/cuda/cuda_kernel_common.cuh"
 #include "infinicore.h"
+
+#ifdef ENABLE_INFINI_CUB
+#include "../../../../infinicub/include/cub_algorithms.cuh"
+#else
 #include <cub/device/device_radix_sort.cuh>
 #include <cub/device/device_reduce.cuh>
 #include <cub/device/device_scan.cuh>
+#endif
 
 namespace op::random_sample::cuda {
 
@@ -16,10 +21,18 @@ static cudaError argMax_(
     void *workspace_ptr,
     size_t &workspace_len,
     cudaStream_t stream) {
+
+#ifdef ENABLE_INFINI_CUB
+    return infini_cub::cub_DeviceReduce_ArgMax(
+        workspace_ptr, workspace_len,
+        logits, kv_pair, n,
+        stream);
+#else
     return cub::DeviceReduce::ArgMax(
         workspace_ptr, workspace_len,
         logits, kv_pair, n,
         stream);
+#endif
 }
 
 template <class Tval, class Tidx>
@@ -29,6 +42,15 @@ static cudaError radixSort(
     const Tidx *val_in, Tidx *val_out,
     int n,
     cudaStream_t stream) {
+
+#ifdef ENABLE_INFINI_CUB
+    return infini_cub::cub_DeviceRadixSort_SortPairsDescending(
+        workspace_ptr, workspace_len,
+        key_in, key_out,
+        val_in, val_out,
+        n,
+        stream);
+#else
     return cub::DeviceRadixSort::SortPairsDescending(
         workspace_ptr, workspace_len,
         key_in, key_out,
@@ -36,6 +58,7 @@ static cudaError radixSort(
         n,
         0, sizeof(Tval) * 8,
         stream);
+#endif
 }
 
 template <class T>
@@ -43,10 +66,18 @@ static cudaError inclusiveSum(
     void *workspace_ptr, size_t &workspace_len,
     T *data, int n,
     cudaStream_t stream) {
-    return cub::DeviceScan::InclusiveSum(
+
+#ifdef ENABLE_INFINI_CUB
+    return infini_cub::cub_DeviceScan_InclusiveSum(
         workspace_ptr, workspace_len,
+        data, n,
+        stream);
+#else
+    return cub::DeviceScan::InclusiveSum(
+        workspace_ptr, workspace_len, 
         data, data, n,
         stream);
+#endif
 }
 
 // ↑↑↑ 重新封装 cub api，减少模板参数，方便调用

--- a/xmake.lua
+++ b/xmake.lua
@@ -12,6 +12,13 @@ if is_mode("debug") then
     add_defines("DEBUG_MODE")
 end
 
+-- infinicub
+option("prebuild")
+    set_default(false)
+    set_showmenu(true)
+    set_description("Enable or disable cub package")
+option_end()
+
 -- CPU
 option("cpu")
     set_default(true)

--- a/xmake/cub.lua
+++ b/xmake/cub.lua
@@ -1,0 +1,17 @@
+package("infinicub")
+    set_description("Build infinicub library.")
+
+    add_versions("1.0.0", "commit-hash-or-sha256-for-v1.0.0")
+    add_versions("1.0.1", "commit-hash-or-sha256-for-v1.0.1")
+
+    set_sourcedir(path.join(os.scriptdir(), "../src/infinicub"))
+  
+    local dir = os.getenv("INFINI_ROOT") or (os.getenv(is_host("windows") and "HOMEPATH" or "HOME") .. "/.infini")
+    set_installdir(path.join(dir,"packages/infinicub/", get_config("plat"), get_config("arch"), get_config("mode")))
+
+    add_configs("shared", {default = false, type = "boolean", readonly = true})
+    on_install(function (package)
+        local configs = {}
+        import("package.tools.xmake").install(package, configs)
+    end)
+package_end()

--- a/xmake/cuda.lua
+++ b/xmake/cuda.lua
@@ -8,6 +8,8 @@ if CUDNN_ROOT ~= nil then
     add_includedirs(CUDNN_ROOT .. "/include")
 end
 
+add_requires("infinicub 1.0.0", {optional = true, configs = {shared = false}})
+
 target("infiniop-cuda")
     set_kind("static")
     add_deps("infini-utils")
@@ -17,6 +19,12 @@ target("infiniop-cuda")
     set_toolchains("cuda")
     add_links("cublas", "cudnn")
     add_cugencodes("native")
+
+    if has_config("prebuild") then
+        add_defines("ENABLE_INFINI_CUB")
+        includes("cub.lua")
+        add_packages("infinicub")
+    end
 
     if is_plat("windows") then
         add_cuflags("-Xcompiler=/utf-8", "--expt-relaxed-constexpr", "--allow-unsupported-compiler")


### PR DESCRIPTION
**描述**
在infinicub包中编译nvidia的cub模板函数，得到ininicub.a静态库，安装在~/.infini/package/目录下。在编译InfiniCore时，可以直接链接 ~/.infini/package/中的ininicub.a静态库。因此，不必每次都编译cub模板函数，减少了编译时间。

ps：每台机器只会在**第一次**执行 `xmake f --nv-gpu=true --cuda=$CUDA_HOME --prebuild=true -cv `时，编译并安装。

修改前：185.13s。
![前](https://github.com/user-attachments/assets/2ed17317-125e-4290-9a70-dc599a46e29e)

修改后：  30.49 s。
![后](https://github.com/user-attachments/assets/a85784fc-c3fb-4c2e-84ab-8c878589511f)

编译耗时约减少了**83**%。

**修改内容：**
修改1： 增加了infinicub包，在./src/infinicub/目录下。
修改2： 增加了描述infinicub包信息的cub.lua文件，在./xmake/目录下。
修改3： 修改了./xmake/cuda.lua文件，在infiniop-cuda目标中，增加了infinicub包相关内容。
修改4： 修改了./xmake.lua文件，增加了prebuild参数。
修改5： 修改了readme文件的注释。

由于修改了random_sample的cuda的代码，需要重新测试：
测试通过!
![Screenshot from 2025-07-07 15-57-14](https://github.com/user-attachments/assets/e725f390-1ed7-453c-a98c-088affd1d5f6)
